### PR TITLE
Update Node.js version in workflow to 24.x

### DIFF
--- a/.github/workflows/watcher.yml
+++ b/.github/workflows/watcher.yml
@@ -28,10 +28,10 @@ jobs:
       GHWATCHER_BASEURL: https://api.github.com
     steps:
       - uses: actions/checkout@v5
-      - name: Use Node.js 20.x
+      - name: Use Node.js 24.x
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 24
       - name: npm setup
         run: npm install
       - name: ${{ matrix.org }} - exec watcher


### PR DESCRIPTION
* Updated the Node.js version in `.github/workflows/watcher.yml` from 20.x to 24.x for the watcher job setup.